### PR TITLE
Fix: ESI API status endpoint

### DIFF
--- a/xiaobawang/plugins/core/api/base.py
+++ b/xiaobawang/plugins/core/api/base.py
@@ -4,6 +4,7 @@ import httpx
 from nonebot import logger
 
 from ..utils.common.http_client import get_client
+from ..config import plugin_config
 
 
 class BaseClient:
@@ -14,7 +15,9 @@ class BaseClient:
     def __init__(self):
         self._client: httpx.AsyncClient | None = get_client()
         self._base_url: str = ""
-
+        self.headers: dict[str, str] = {}
+        self.headers["user-agent"] = plugin_config.user_agent
+        
     async def _get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict:
         """
         GET
@@ -25,7 +28,7 @@ class BaseClient:
         url = f"{self._base_url}{endpoint}"
 
         try:
-            response = await self._client.get(url, params=params)
+            response = await self._client.get(url, params=params, headers=self.headers)
             logger.debug(f"[{endpoint}]{response.status_code} {response.url}")
             response.raise_for_status()
             return response.json()
@@ -45,7 +48,7 @@ class BaseClient:
         """
         url = f"{self._base_url}{endpoint}"
         try:
-            response = await self._client.post(url, json=data)
+            response = await self._client.post(url, json=data, headers=self.headers)
             logger.debug(f"[{endpoint}]{response.status_code} {response.url}\ndata: {data}")
             logger.debug(f"响应内容: {response.json()}")
             response.raise_for_status()

--- a/xiaobawang/plugins/core/api/esi/market.py
+++ b/xiaobawang/plugins/core/api/esi/market.py
@@ -16,7 +16,7 @@ from nonebot_plugin_apscheduler import scheduler
 
 class MarketHandle:
     def __init__(self):
-        self.esi_base_url: str = "https://esi.evetech.net/latest/"
+        self.esi_base_url: str = "https://esi.evetech.net/"
         self.client = get_client()
 
         if plugin_config.EVE_MARKET_API == "esi_cache":

--- a/xiaobawang/plugins/core/api/esi/market.py
+++ b/xiaobawang/plugins/core/api/esi/market.py
@@ -16,7 +16,7 @@ from nonebot_plugin_apscheduler import scheduler
 
 class MarketHandle:
     def __init__(self):
-        self.esi_base_url: str = "https://esi.evetech.net/latest/"
+        self.esi_base_url: str = "https://esi.evetech.net/"
         self.client = get_client()
 
         if plugin_config.EVE_MARKET_API == "esi_cache":
@@ -35,7 +35,7 @@ class MarketHandle:
         :return: 市场数据列表
         """
         url = f"{self.esi_base_url}markets/{region_id}/orders/"
-        params = {}
+        params = {"X-Compatibility-Date": "2025-12-16"}
         if type_id:
             params["type_id"] = type_id
 
@@ -204,7 +204,7 @@ class MarketHandle:
             return cached_data
 
         url = f"{self.esi_base_url}markets/{region_id}/history/"
-        params = {"type_id": type_id}
+        params = {"type_id": type_id, "X-Compatibility-Date": "2025-12-16"}
 
         try:
             response = await self.client.get(url, params=params)

--- a/xiaobawang/plugins/core/api/esi/market.py
+++ b/xiaobawang/plugins/core/api/esi/market.py
@@ -18,6 +18,7 @@ class MarketHandle:
     def __init__(self):
         self.esi_base_url: str = "https://esi.evetech.net/"
         self.client = get_client()
+        self.headers = {"X-Compatibility-Date": "2025-12-16", "User-Agent": plugin_config.user_agent}
 
         if plugin_config.EVE_MARKET_API == "esi_cache":
             logger.info("启用定时市场缓存")
@@ -35,12 +36,13 @@ class MarketHandle:
         :return: 市场数据列表
         """
         url = f"{self.esi_base_url}markets/{region_id}/orders/"
-        params = {"X-Compatibility-Date": "2025-12-16"}
+        
+        params = {}
         if type_id:
             params["type_id"] = type_id
 
         try:
-            response = await self.client.get(url, params=params)
+            response = await self.client.get(url, params=params, headers=self.headers)
             response.raise_for_status()
 
             total_pages = int(response.headers.get("x-pages", 1))
@@ -77,12 +79,12 @@ class MarketHandle:
         :return: 页面数据
         """
         try:
-            response = await self.client.get(url, params=params)
+            response = await self.client.get(url, params=params, headers=self.headers)
             response.raise_for_status()
             return response.json()
         except Exception as e:
             page = params.get("page", "unknown")
-            logger.error(f"获取市场数据第 {page} 页失败: {e.__traceback__}")
+            logger.error(f"获取市场数据第 {page} 页失败: {e}\n{traceback.format_exc()}")
             return []
 
     @classmethod
@@ -204,10 +206,10 @@ class MarketHandle:
             return cached_data
 
         url = f"{self.esi_base_url}markets/{region_id}/history/"
-        params = {"type_id": type_id, "X-Compatibility-Date": "2025-12-16"}
+        params = {"type_id": type_id}
 
         try:
-            response = await self.client.get(url, params=params)
+            response = await self.client.get(url, params=params, headers=self.headers)
             response.raise_for_status()
             history_data = response.json()
 

--- a/xiaobawang/plugins/core/api/esi/universe.py
+++ b/xiaobawang/plugins/core/api/esi/universe.py
@@ -176,7 +176,7 @@ class ESIClient(BaseClient):
         :return: API状态
         """
         try:
-            endpoint = f"https://esi.evetech.net/status?{ESI_VERSION_TAG}"
+            endpoint = f"https://esi.evetech.net/meta/status?{ESI_VERSION_TAG}"
             r = await self._client.get(url=endpoint)
             r.raise_for_status()
             data = r.json()

--- a/xiaobawang/plugins/core/api/esi/universe.py
+++ b/xiaobawang/plugins/core/api/esi/universe.py
@@ -10,11 +10,13 @@ ALLOW_CATEGORY = Literal[
     "agents", "corporations", "characters", "alliances", "systems", "constellations", "regions", "stations"
 ]
 
+ESI_VERSION_TAG = "X-Compatibility-Date=2025-12-16"
+
 
 class ESIClient(BaseClient):
     def __init__(self):
         super().__init__()
-        self._base_url = "https://esi.evetech.net/latest"
+        self._base_url = "https://esi.evetech.net"
         self.batch_size = 500
 
     @cache_result(expire_time=cache.TIME_DAY, prefix="esi:get_universe_id", exclude_args=[0])
@@ -33,7 +35,7 @@ class ESIClient(BaseClient):
         Return:
             ID int
         """
-        endpoint = f"/universe/ids/?language={lang}"
+        endpoint = f"/universe/ids/?language={lang}&{ESI_VERSION_TAG}"
         data = [name]
         r = await self._post(endpoint, data)
 
@@ -55,7 +57,7 @@ class ESIClient(BaseClient):
             分类的名称列表
         """
         result = {}
-        endpoint = "/universe/names/?datasource=tranquility"
+        endpoint = f"/universe/names/?{ESI_VERSION_TAG}"
 
         if isinstance(ids, int):
             ids = [ids]
@@ -95,17 +97,23 @@ class ESIClient(BaseClient):
             包含星系信息的字典
         """
         try:
-            system_resp = await self._get(f"/universe/systems/{system_id}/")
+            system_resp = await self._get(
+                f"/universe/systems/{system_id}/?{ESI_VERSION_TAG}"
+            )
             constellation_id = system_resp.get("constellation_id")
 
             const_resp = {}
             if constellation_id:
-                const_resp = await self._get(f"/universe/constellations/{constellation_id}/")
+                const_resp = await self._get(
+                    f"/universe/constellations/{constellation_id}/?{ESI_VERSION_TAG}"
+                )
 
             region_resp = {}
             region_id = const_resp.get("region_id")
             if region_id:
-                region_resp = await self._get(f"/universe/regions/{region_id}/")
+                region_resp = await self._get(
+                    f"/universe/regions/{region_id}/?{ESI_VERSION_TAG}"
+                )
 
             return {
                 "system_id": system_id,
@@ -129,7 +137,7 @@ class ESIClient(BaseClient):
         :return: 卫星信息
         """
         try:
-            endpoint = f"/universe/moons/{moon_id!s}/?datasource=tranquility"
+            endpoint = f"/universe/moons/{moon_id!s}/?{ESI_VERSION_TAG}"
             data = await self._get(endpoint)
             return data
         except Exception as e:
@@ -150,7 +158,9 @@ class ESIClient(BaseClient):
         :return:
         """
         try:
-            endpoint = f"/universe/{type_}/{_id}/?datasource&language={lang}"
+            endpoint = (
+                f"/universe/{type_}/{_id}/?datasource&language={lang}&{ESI_VERSION_TAG}"
+            )
             data = await self._get(endpoint)
             if "name" in data:
                 return data["name"]
@@ -166,7 +176,7 @@ class ESIClient(BaseClient):
         :return: API状态
         """
         try:
-            endpoint = "https://esi.evetech.net/status?X-Compatibility-Date=2025-12-16"
+            endpoint = f"https://esi.evetech.net/status?{ESI_VERSION_TAG}"
             r = await self._client.get(url=endpoint)
             r.raise_for_status()
             data = r.json()
@@ -199,7 +209,7 @@ class ESIClient(BaseClient):
         :return: 服务器状态
         """
         try:
-            endpoint = "/status/?datasource=tranquility"
+            endpoint = f"/status/?{ESI_VERSION_TAG}"
             return await self._get(endpoint)
         except Exception as e:
             logger.error(f"获取服务器状态失败: {e}")
@@ -213,7 +223,7 @@ class ESIClient(BaseClient):
         :return: 角色的公共信息
         """
         try:
-            endpoint = f"/characters/{character_id}/?datasource=tranquility"
+            endpoint = f"/characters/{character_id}/?{ESI_VERSION_TAG}"
             return await self._get(endpoint)
         except Exception as e:
             logger.error(f"获取角色公共信息失败: {e}")

--- a/xiaobawang/plugins/core/api/esi/universe.py
+++ b/xiaobawang/plugins/core/api/esi/universe.py
@@ -18,6 +18,7 @@ class ESIClient(BaseClient):
         super().__init__()
         self._base_url = "https://esi.evetech.net"
         self.batch_size = 500
+        self.headers["X-Compatibility-Date"] = "2025-12-16"
 
     @cache_result(expire_time=cache.TIME_DAY, prefix="esi:get_universe_id", exclude_args=[0])
     async def get_universe_id(
@@ -176,28 +177,24 @@ class ESIClient(BaseClient):
         :return: API状态
         """
         try:
-            endpoint = f"https://esi.evetech.net/meta/status?{ESI_VERSION_TAG}"
-            r = await self._client.get(url=endpoint)
-            r.raise_for_status()
-            data = r.json()
-            green, yellow, red, eve_status = 0, 0, 0,  "eve_status"
+            logger.debug(self.headers)
+            endpoint = "/meta/status"
+            data = await self._get(endpoint)
+            green, yellow, red = 0, 0, 0
             for i in data:
                 status = i.get("status")
-                if status == "green":
+                if status == "OK":
                     green += 1
-                elif status == "yellow":
+                elif status == "Degraded":
                     yellow += 1
                 else:
                     red += 1
-                if i.get("endpoint") == "esi-status-protobuf":
-                    eve_status = status
 
             return {
                 "green": green,
                 "yellow": yellow,
                 "red": red,
-                "total": len(data),
-                "eve_status": eve_status
+                "total": len(data)
             }
         except Exception as e:
             logger.error(f"获取API状态失败: {e}")

--- a/xiaobawang/plugins/core/api/esi/universe.py
+++ b/xiaobawang/plugins/core/api/esi/universe.py
@@ -166,7 +166,7 @@ class ESIClient(BaseClient):
         :return: API状态
         """
         try:
-            endpoint = "https://esi.evetech.net/status.json?version=latest"
+            endpoint = "https://esi.evetech.net/status?X-Compatibility-Date=2025-12-16"
             r = await self._client.get(url=endpoint)
             r.raise_for_status()
             data = r.json()

--- a/xiaobawang/plugins/core/api/esi/universe.py
+++ b/xiaobawang/plugins/core/api/esi/universe.py
@@ -14,7 +14,7 @@ ALLOW_CATEGORY = Literal[
 class ESIClient(BaseClient):
     def __init__(self):
         super().__init__()
-        self._base_url = "https://esi.evetech.net/latest"
+        self._base_url = "https://esi.evetech.net"
         self.batch_size = 500
 
     @cache_result(expire_time=cache.TIME_DAY, prefix="esi:get_universe_id", exclude_args=[0])
@@ -55,7 +55,7 @@ class ESIClient(BaseClient):
             分类的名称列表
         """
         result = {}
-        endpoint = "/universe/names/?datasource=tranquility"
+        endpoint = "/universe/names/"
 
         if isinstance(ids, int):
             ids = [ids]
@@ -129,7 +129,7 @@ class ESIClient(BaseClient):
         :return: 卫星信息
         """
         try:
-            endpoint = f"/universe/moons/{moon_id!s}/?datasource=tranquility"
+            endpoint = f"/universe/moons/{moon_id!s}/"
             data = await self._get(endpoint)
             return data
         except Exception as e:
@@ -150,7 +150,7 @@ class ESIClient(BaseClient):
         :return:
         """
         try:
-            endpoint = f"/universe/{type_}/{_id}/?datasource&language={lang}"
+            endpoint = f"/universe/{type_}/{_id}/?language={lang}"
             data = await self._get(endpoint)
             if "name" in data:
                 return data["name"]
@@ -166,7 +166,7 @@ class ESIClient(BaseClient):
         :return: API状态
         """
         try:
-            endpoint = "https://esi.evetech.net/status.json?version=latest"
+            endpoint = "https://esi.evetech.net/meta/status"
             r = await self._client.get(url=endpoint)
             r.raise_for_status()
             data = r.json()
@@ -199,7 +199,7 @@ class ESIClient(BaseClient):
         :return: 服务器状态
         """
         try:
-            endpoint = "/status/?datasource=tranquility"
+            endpoint = "/status/"
             return await self._get(endpoint)
         except Exception as e:
             logger.error(f"获取服务器状态失败: {e}")
@@ -213,7 +213,7 @@ class ESIClient(BaseClient):
         :return: 角色的公共信息
         """
         try:
-            endpoint = f"/characters/{character_id}/?datasource=tranquility"
+            endpoint = f"/characters/{character_id}/"
             return await self._get(endpoint)
         except Exception as e:
             logger.error(f"获取角色公共信息失败: {e}")

--- a/xiaobawang/plugins/core/api/killmail.py
+++ b/xiaobawang/plugins/core/api/killmail.py
@@ -23,9 +23,9 @@ async def get_zkb_killmail(
     except Exception as e:
         raise e
     zkb = r.json()[0].get("zkb")
-    esi_url = f"https://esi.evetech.net/killmails/{kill_id}/{zkb.get('hash')}/?X-Compatibility-Date=2025-12-16"
+    esi_url = f"https://esi.evetech.net/killmails/{kill_id}/{zkb.get('hash')}/"
     try:
-        r = await client.get(esi_url)
+        r = await client.get(esi_url, headers={"X-Compatibility-Date": "2025-12-16"})
         r.raise_for_status()
     except Exception as e:
         logger.error(e)

--- a/xiaobawang/plugins/core/api/killmail.py
+++ b/xiaobawang/plugins/core/api/killmail.py
@@ -23,7 +23,7 @@ async def get_zkb_killmail(
     except Exception as e:
         raise e
     zkb = r.json()[0].get("zkb")
-    esi_url = f"https://esi.evetech.net/latest/killmails/{kill_id}/{zkb.get('hash')}/"
+    esi_url = f"https://esi.evetech.net/killmails/{kill_id}/{zkb.get('hash')}/"
     try:
         r = await client.get(esi_url)
         r.raise_for_status()

--- a/xiaobawang/plugins/core/api/killmail.py
+++ b/xiaobawang/plugins/core/api/killmail.py
@@ -23,7 +23,7 @@ async def get_zkb_killmail(
     except Exception as e:
         raise e
     zkb = r.json()[0].get("zkb")
-    esi_url = f"https://esi.evetech.net/latest/killmails/{kill_id}/{zkb.get('hash')}/"
+    esi_url = f"https://esi.evetech.net/killmails/{kill_id}/{zkb.get('hash')}/?X-Compatibility-Date=2025-12-16"
     try:
         r = await client.get(esi_url)
         r.raise_for_status()

--- a/xiaobawang/plugins/core/config.py
+++ b/xiaobawang/plugins/core/config.py
@@ -15,7 +15,7 @@ class Config(BaseModel):
 
     proxy: str = None
 
-    user_agent: str = None
+    user_agent: str = "xiaobawang/1.1.0 (https://github.com/zifox666/xiaobawang)"
 
     zkb_listener_method: str = "r2z2"
     zkb_listener_url: str = "https://zkillredisq.stream/listen.php"

--- a/xiaobawang/plugins/core/helper/status.py
+++ b/xiaobawang/plugins/core/helper/status.py
@@ -40,7 +40,9 @@ class EVEServerStatus:
         self.api_status = await esi_client.get_api_status()
         try:
             if not plugin_config.tq_status_url:
-                r = await self._client.get("https://esi.evetech.net/latest/status/?datasource=tranquility")
+                r = await self._client.get(
+                    "https://esi.evetech.net/status/?X-Compatibility-Date=2025-12-16"
+                )
                 if r.status_code == 200:
                     self.status = r.json()
                 elif r.status_code // 100 == 5:

--- a/xiaobawang/plugins/core/helper/status.py
+++ b/xiaobawang/plugins/core/helper/status.py
@@ -40,7 +40,7 @@ class EVEServerStatus:
         self.api_status = await esi_client.get_api_status()
         try:
             if not plugin_config.tq_status_url:
-                r = await self._client.get("https://esi.evetech.net/latest/status/?datasource=tranquility")
+                r = await self._client.get("https://esi.evetech.net/status/")
                 if r.status_code == 200:
                     self.status = r.json()
                 elif r.status_code // 100 == 5:

--- a/xiaobawang/plugins/core/helper/status.py
+++ b/xiaobawang/plugins/core/helper/status.py
@@ -40,9 +40,7 @@ class EVEServerStatus:
         self.api_status = await esi_client.get_api_status()
         try:
             if not plugin_config.tq_status_url:
-                r = await self._client.get(
-                    "https://esi.evetech.net/status/?X-Compatibility-Date=2025-12-16"
-                )
+                r = await self._client.get("https://esi.evetech.net/status/")
                 if r.status_code == 200:
                     self.status = r.json()
                 elif r.status_code // 100 == 5:

--- a/xiaobawang/plugins/core/utils/common/http_client.py
+++ b/xiaobawang/plugins/core/utils/common/http_client.py
@@ -8,6 +8,29 @@ from ...config import HEADERS, plugin_config
 
 # 全局客户端实例
 _client: httpx.AsyncClient | None = None
+ESI_COMPATIBILITY_HEADER = "X-Compatibility-Date"
+ESI_COMPATIBILITY_DATE = "2025-12-16"
+ESI_HOST = "esi.evetech.net"
+
+
+def _inject_esi_compatibility_header(request: httpx.Request) -> None:
+    """Automatically attach ESI compatibility date for ESI host requests."""
+    if request.url.host == ESI_HOST and ESI_COMPATIBILITY_HEADER not in request.headers:
+        request.headers[ESI_COMPATIBILITY_HEADER] = ESI_COMPATIBILITY_DATE
+
+
+def _build_event_hooks(existing: dict | None = None) -> dict:
+    hooks = {} if existing is None else dict(existing)
+    request_hooks = list(hooks.get("request", []))
+    request_hooks.append(_inject_esi_compatibility_header)
+    hooks["request"] = request_hooks
+    return hooks
+
+
+def create_client(**kwargs) -> AsyncClient:
+    """Create a configured httpx client with shared request hooks."""
+    event_hooks = _build_event_hooks(kwargs.pop("event_hooks", None))
+    return httpx.AsyncClient(follow_redirects=True, event_hooks=event_hooks, **kwargs)
 
 
 async def init_client(
@@ -26,8 +49,12 @@ async def init_client(
     )
     limits = httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_keepalive_connections)
 
-    _client = httpx.AsyncClient(
-        timeout=timeout, limits=limits, proxy=plugin_config.proxy, follow_redirects=True, headers=HEADERS, **kwargs
+    _client = create_client(
+        timeout=timeout,
+        limits=limits,
+        proxy=plugin_config.proxy,
+        headers=HEADERS,
+        **kwargs,
     )
 
     return _client

--- a/xiaobawang/plugins/frt_pap/__init__.py
+++ b/xiaobawang/plugins/frt_pap/__init__.py
@@ -76,7 +76,7 @@ async def get_corp_name(corp_id: int) -> str:
     try:
         async with httpx.AsyncClient() as client:
             r = await client.post(
-                "https://esi.evetech.net/latest/universe/names/",
+                "https://esi.evetech.net/universe/names/?X-Compatibility-Date=2025-12-16",
                 json=[corp_id],
                 headers={"Content-Type": "application/json"}
             )
@@ -251,6 +251,3 @@ async def _handle_pap(
         )
 
         await pap_query.finish(UniMessage.image(raw=pic))
-
-
-

--- a/xiaobawang/plugins/frt_pap/__init__.py
+++ b/xiaobawang/plugins/frt_pap/__init__.py
@@ -8,6 +8,7 @@ from nonebot.exception import FinishedException
 from nonebot.plugin import PluginMetadata
 
 from .config import Config, plugin_config
+from ..core.utils.common.http_client import create_client
 
 require("nonebot_plugin_alconna")
 require("nonebot_plugin_uninfo")
@@ -74,9 +75,9 @@ async def get_corp_name(corp_id: int) -> str:
     if not corp_id:
         return "Unknown Corporation"
     try:
-        async with httpx.AsyncClient() as client:
+        async with create_client() as client:
             r = await client.post(
-                "https://esi.evetech.net/latest/universe/names/",
+                "https://esi.evetech.net/universe/names/",
                 json=[corp_id],
                 headers={"Content-Type": "application/json"}
             )
@@ -251,6 +252,3 @@ async def _handle_pap(
         )
 
         await pap_query.finish(UniMessage.image(raw=pic))
-
-
-

--- a/xiaobawang/plugins/structure_notifications/service.py
+++ b/xiaobawang/plugins/structure_notifications/service.py
@@ -23,10 +23,7 @@ require_scopes("structure_notifications", [
 
 cache = get_cache("structure_notifications")
 
-ESI_NOTIFICATIONS_URL = (
-    "https://esi.evetech.net/characters/{character_id}/notifications/"
-    + "?X-Compatibility-Date=2025-12-16"
-)
+ESI_NOTIFICATIONS_URL = "https://esi.evetech.net/characters/{character_id}/notifications/"
 
 
 # ── 订阅 CRUD ──────────────────────────────────────────────
@@ -125,6 +122,7 @@ async def fetch_notifications(character_id: int) -> list[dict]:
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {access_token}",
+        "X-Compatibility-Date": "2025-12-16",
     }
 
     proxy = plugin_config.structure_notify_proxy

--- a/xiaobawang/plugins/structure_notifications/service.py
+++ b/xiaobawang/plugins/structure_notifications/service.py
@@ -23,7 +23,10 @@ require_scopes("structure_notifications", [
 
 cache = get_cache("structure_notifications")
 
-ESI_NOTIFICATIONS_URL = "https://esi.evetech.net/latest/characters/{character_id}/notifications/"
+ESI_NOTIFICATIONS_URL = (
+    "https://esi.evetech.net/characters/{character_id}/notifications/"
+    + "?X-Compatibility-Date=2025-12-16"
+)
 
 
 # ── 订阅 CRUD ──────────────────────────────────────────────

--- a/xiaobawang/plugins/structure_notifications/service.py
+++ b/xiaobawang/plugins/structure_notifications/service.py
@@ -5,12 +5,12 @@
 import json
 from datetime import datetime, timezone
 
-import httpx
 from nonebot import logger
 from nonebot_plugin_orm import get_session
 from sqlalchemy import select
 
 from ..cache import get_cache
+from ..core.utils.common.http_client import create_client
 from ..eve_oauth.api import get_access_token, require_scopes
 from .categories import ALL_STRUCTURE_TYPES, TYPE_TO_CATEGORY, get_type_label
 from .config import plugin_config
@@ -23,7 +23,7 @@ require_scopes("structure_notifications", [
 
 cache = get_cache("structure_notifications")
 
-ESI_NOTIFICATIONS_URL = "https://esi.evetech.net/latest/characters/{character_id}/notifications/"
+ESI_NOTIFICATIONS_URL = "https://esi.evetech.net/characters/{character_id}/notifications/"
 
 
 # ── 订阅 CRUD ──────────────────────────────────────────────
@@ -126,7 +126,7 @@ async def fetch_notifications(character_id: int) -> list[dict]:
 
     proxy = plugin_config.structure_notify_proxy
     try:
-        async with httpx.AsyncClient(timeout=20, proxy=proxy) as client:
+        async with create_client(timeout=20, proxy=proxy) as client:
             resp = await client.get(url, headers=headers)
             if resp.status_code == 304:
                 return []


### PR DESCRIPTION
新增加了强制参数，否则会404掉

https://developers.eveonline.com/api-explorer#/operations/GetStatus

X-Compatibility-Date
string<date>
__required__

The compatibility date for the request.
Allowed value:
2025-12-16